### PR TITLE
Lock networkx version in tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ deps =
     cfn-lint==0.38.0
     freezegun==1.0.0
     moto==1.3.16
+    networkx==2.5.1
     pytest
     pytest-mock
     -r requirements.txt


### PR DESCRIPTION
Lock networkx to version 2.5.1 in tox test runs, since moto doesn't play nicely with newer networkx releases.