### PR TITLE
DP-2207: Fix serverless deploy

### DIFF
--- a/serverless.yaml
+++ b/serverless.yaml
@@ -48,7 +48,15 @@ functions:
   update_cf_status:
     handler: notifications.sns_handler.handle
     events:
-      - sns: !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:event-stream-api-cloudformation-events"
+      - sns:
+          arn:
+            Fn::Join:
+              - ':'
+              - - 'arn:aws:sns'
+                - Ref: 'AWS::Region'
+                - Ref: 'AWS::AccountId'
+                - 'event-stream-api-cloudformation-events'
+          topicName: event-stream-api-cloudformation-events
 
 plugins:
   - serverless-python-requirements


### PR DESCRIPTION
Serverless deploy seems to fail after removing the `serverless-pseudo-parameters` plugin (?), and does not seem to accept the following for specifying the SNS topic ARN:
```
...
    events:
      - sns: !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:event-stream-api-cloudformation-events"
```
```
TypeError: Cannot read property 'replace' of undefined
      at Object.normalizeNameToAlphaNumericOnly (/home/runner/work/okdata-event-stream-api/okdata-event-stream-api/node_modules/serverless/lib/plugins/aws/lib/naming.js:32:36)
```

Using 
```
- sns: "arn:aws:sns:${aws:region}:${aws:accountId}:event-stream-api-cloudformation-events"
```
seems to work however if pinning a newer serverless version is an option.