### PR TITLE
Avoid mixing implicit and explicit returns

### DIFF
--- a/test/resources/events_resource_test.py
+++ b/test/resources/events_resource_test.py
@@ -135,5 +135,6 @@ def mock_dataset(monkeypatch):
     def get_dataset(self, dataset_id, *args, **kwargs):
         if dataset_id == "foo":
             return {"Id": "foo", "accessRights": "public"}
+        return None
 
     monkeypatch.setattr(Dataset, "get_dataset", get_dataset)


### PR DESCRIPTION
Fixes a CodeQL warning.